### PR TITLE
Change stress analysis to stress update

### DIFF
--- a/2d/hydrostatic_column/quad-mesh/mpm-file.json
+++ b/2d/hydrostatic_column/quad-mesh/mpm-file.json
@@ -49,7 +49,7 @@
   },
   "analysis": {
     "type": "MPMExplicit2D",
-    "stress_analysis": "usl",
+    "stress_update": "usl",
     "dt": 0.00001,
     "uuid": "hydrostatic_usf",
     "nsteps": 10000,

--- a/2d/hydrostatic_column/quad-mesh/mpm.json
+++ b/2d/hydrostatic_column/quad-mesh/mpm.json
@@ -59,7 +59,7 @@
   },
   "analysis": {
     "type": "MPMExplicit2D",
-    "stress_analysis": "usl",
+    "stress_update": "usl",
     "dt": 0.00001,
     "uuid": "hydrostatic_usf",
     "nsteps": 10000,

--- a/2d/mc_uniaxial_compression/mpm.json
+++ b/2d/mc_uniaxial_compression/mpm.json
@@ -63,7 +63,7 @@
   },
   "analysis": {
     "type": "MPMExplicit2D",
-    "stress_analysis": "usf",
+    "stress_update": "usf",
     "dt": 0.000001,
     "uuid": "UCT-2d",
     "nsteps": 5000,

--- a/2d/plate_with_hole/cartesian/mpm.json
+++ b/2d/plate_with_hole/cartesian/mpm.json
@@ -61,7 +61,7 @@
   },
   "analysis": {
     "type": "MPMExplicit2D",
-    "stress_analysis": "usf",
+    "stress_update": "usf",
     "velocity_update": true,
     "dt": 1.0E-4,
     "uuid": "plate-hole",

--- a/2d/plate_with_hole/isoparametric/mpm.json
+++ b/2d/plate_with_hole/isoparametric/mpm.json
@@ -60,7 +60,7 @@
   },
   "analysis": {
     "type": "MPMExplicit2D",
-    "stress_analysis": "usf",
+    "stress_update": "usf",
     "velocity_update": true,
     "dt": 1.0E-4,
     "uuid": "plate-hole",

--- a/2d/thick_walled_cylinder/mpm.json
+++ b/2d/thick_walled_cylinder/mpm.json
@@ -53,7 +53,7 @@
   },
   "analysis": {
     "type": "MPMExplicit2D",
-    "stress_analysis": "usl",
+    "stress_update": "usl",
     "dt": 1.0E-6,
     "uuid": "thickwalled-cylinder",
     "nsteps": 1000,

--- a/3d/dam-break/mpm.json
+++ b/3d/dam-break/mpm.json
@@ -55,7 +55,7 @@
   },
   "analysis" : {
     "type" : "MPMExplicit3D",
-    "stress_analysis" : "usf", 
+    "stress_update" : "usf",
     "uuid": "dambreak-3d",
     "dt" : 1.0E-4,
     "nsteps" : 20000,

--- a/3d/hydrostatic_column/mpm.json
+++ b/3d/hydrostatic_column/mpm.json
@@ -33,7 +33,7 @@
       "generator": {
         "check_duplicates": true,
         "particle_type": "P3D",
-        "cset_id": -1,  
+        "cset_id": -1,
         "pset_id": 0,
         "material_id": 1,
         "nparticles_per_dir": 2,
@@ -62,7 +62,7 @@
   },
   "analysis": {
     "type": "MPMExplicit3D",
-    "stress_analysis": "usl",
+    "stress_update": "usl",
     "dt": 0.00001,
     "uuid": "hydrostatic_usf",
     "nsteps": 10000,

--- a/3d/inject/mpm.json
+++ b/3d/inject/mpm.json
@@ -73,7 +73,7 @@
   },
   "analysis": {
     "type": "MPMExplicit3D",
-    "stress_analysis": "usl",
+    "stress_update": "usl",
     "dt": 0.00001,
     "uuid": "PointInjection",
     "nsteps": 2500,

--- a/3d/sliding_block_inclined_boundary/mpm.json
+++ b/3d/sliding_block_inclined_boundary/mpm.json
@@ -45,7 +45,7 @@
     "type" : "LinearElastic3D",
     "density" : 1800,
     "youngs_modulus": 1.0E+12,
-    "poisson_ratio" : 0.0    
+    "poisson_ratio" : 0.0
     }
   ],
   "external_loading_conditions" : {
@@ -53,7 +53,7 @@
   },
   "analysis" : {
     "type" : "MPMExplicit3D",
-    "stress_analysis" : "usf", 
+    "stress_update" : "usf",
     "dt" : 1.0E-5,
     "uuid" : "boundary_inclined_friction",
     "nsteps" : 1.0E+5,


### PR DESCRIPTION
**Describe the PR**
Not sure why we are still using stress_analysis instead of stress_update in some json file. This will make USF automatically chosen instead of the desired stress_update type.

