### PR TITLE
:wrench: Add phase id to offer a consistent example for vtk state vars

### DIFF
--- a/2d/hydrostatic_column/quad-mesh/mpm-file.json
+++ b/2d/hydrostatic_column/quad-mesh/mpm-file.json
@@ -64,7 +64,8 @@
     "path": "results/",
     "output_steps": 1000,
     "vtk_statevars": [
-      {
+     {
+        "phase_id": 0,
         "statevars" : ["pdstrain"]
       }
     ]


### PR DESCRIPTION
**Describe the PR**
Offer a consistent example for vtk statevariables. Although `phase_id` is an optional argument, it's good to have a whole example. 
This PR adds:
```
    "vtk_statevars": [
     {
        "phase_id": 0,
        "statevars" : ["pdstrain"]
      }
    ]
```

**Related Issues/PRs**
#15 