### PR TITLE
Add vtk_statevars and vtk in all json to fix nightly error

### DIFF
--- a/2d/hydrostatic_column/quad-mesh/mpm-file.json
+++ b/2d/hydrostatic_column/quad-mesh/mpm-file.json
@@ -63,6 +63,7 @@
   "post_processing": {
     "path": "results/",
     "output_steps": 1000,
+    "vtk": [],
     "vtk_statevars": [
      {
         "phase_id": 0,

--- a/2d/hydrostatic_column/quad-mesh/mpm.json
+++ b/2d/hydrostatic_column/quad-mesh/mpm.json
@@ -72,6 +72,8 @@
   },
   "post_processing": {
     "path": "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps": 1000
   }
 }

--- a/2d/hydrostatic_column/triangular-mesh/mpm.json
+++ b/2d/hydrostatic_column/triangular-mesh/mpm.json
@@ -73,6 +73,8 @@
   },
   "post_processing" : {
     "path" : "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps" : 100
   }
 }

--- a/2d/mc_uniaxial_compression/mpm.json
+++ b/2d/mc_uniaxial_compression/mpm.json
@@ -76,6 +76,8 @@
   },
   "post_processing": {
     "path": "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps": 10
   }
 }

--- a/2d/plate_with_hole/cartesian/mpm.json
+++ b/2d/plate_with_hole/cartesian/mpm.json
@@ -74,6 +74,8 @@
   },
   "post_processing": {
     "path": "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps": 1000
   }
 }

--- a/2d/plate_with_hole/isoparametric/mpm.json
+++ b/2d/plate_with_hole/isoparametric/mpm.json
@@ -73,6 +73,8 @@
   },
   "post_processing": {
     "path": "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps": 1000
   }
 }

--- a/2d/sliding_block_inclined_boundary/mpm-file.json
+++ b/2d/sliding_block_inclined_boundary/mpm-file.json
@@ -61,6 +61,8 @@
   },
   "post_processing": {
     "path": "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps": 1000
   }
 }

--- a/2d/sliding_block_inclined_boundary/mpm.json
+++ b/2d/sliding_block_inclined_boundary/mpm.json
@@ -71,6 +71,8 @@
   },
   "post_processing": {
     "path": "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps": 1000
   }
 }

--- a/2d/thick_walled_cylinder/mpm.json
+++ b/2d/thick_walled_cylinder/mpm.json
@@ -65,6 +65,8 @@
   },
   "post_processing": {
     "path": "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps": 100
   }
 }

--- a/2d/uniaxial_stress/mpm.json
+++ b/2d/uniaxial_stress/mpm.json
@@ -61,6 +61,8 @@
   },
   "post_processing": {
     "path": "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps": 1
   }
 }

--- a/2d/uniaxial_traction/mpm-nodal-forces-file.json
+++ b/2d/uniaxial_traction/mpm-nodal-forces-file.json
@@ -57,7 +57,7 @@
     }
   ],
   "analysis" : {
-    "type" : "MPMExplicit2D", 
+    "type" : "MPMExplicit2D",
     "dt" : 0.001,
     "uuid" : "uniaxial-nodal-forces-2d",
     "velocity_update" : true,
@@ -70,6 +70,8 @@
   },
   "post_processing" : {
     "path" : "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps" : 10
   }
 }

--- a/2d/uniaxial_traction/mpm-nodal-forces.json
+++ b/2d/uniaxial_traction/mpm-nodal-forces.json
@@ -60,7 +60,7 @@
     }
   ],
   "analysis" : {
-    "type" : "MPMExplicit2D", 
+    "type" : "MPMExplicit2D",
     "dt" : 0.001,
     "uuid" : "uniaxial-nodal-forces-2d",
     "velocity_update" : true,
@@ -73,6 +73,8 @@
   },
   "post_processing" : {
     "path" : "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps" : 10
   }
 }

--- a/2d/uniaxial_traction/mpm-particle-traction.json
+++ b/2d/uniaxial_traction/mpm-particle-traction.json
@@ -60,7 +60,7 @@
     }
   ],
   "analysis" : {
-    "type" : "MPMExplicit2D", 
+    "type" : "MPMExplicit2D",
     "dt" : 0.001,
     "uuid" : "uniaxial-particle-traction-2d",
     "velocity_update" : true,
@@ -73,6 +73,8 @@
   },
   "post_processing" : {
     "path" : "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps" : 10
   }
 }

--- a/3d/dam-break/mpm.json
+++ b/3d/dam-break/mpm.json
@@ -67,6 +67,8 @@
   },
   "post_processing" : {
     "path" : "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps" : 50
   }
 }

--- a/3d/hydrostatic_column/mpm.json
+++ b/3d/hydrostatic_column/mpm.json
@@ -75,6 +75,8 @@
   },
   "post_processing": {
     "path": "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps": 1000
   }
 }

--- a/3d/inject/mpm.json
+++ b/3d/inject/mpm.json
@@ -86,6 +86,8 @@
   },
   "post_processing": {
     "path": "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps": 10
   }
 }

--- a/3d/sliding_block_inclined_boundary/mpm.json
+++ b/3d/sliding_block_inclined_boundary/mpm.json
@@ -66,6 +66,8 @@
   },
   "post_processing" : {
     "path" : "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps" : 1000
   }
 }

--- a/3d/uniaxial_stress/mpm.json
+++ b/3d/uniaxial_stress/mpm.json
@@ -61,6 +61,8 @@
   },
   "post_processing": {
     "path": "results/",
+    "vtk": [],
+    "vtk_statevars": [],
     "output_steps": 1
   }
 }


### PR DESCRIPTION
**Describe the PR**
Since we are removing try and catch in PR https://github.com/cb-geo/mpm/pull/683 and https://github.com/cb-geo/mpm/pull/684, `"vtk"` and `"vtk_statevars"` keywords are necessary in the json file. I am adding those to the benchmark .json.

