### PR TITLE
:bug: update to global min and max values

### DIFF
--- a/2d/sliding_block_inclined_boundary/test_benchmark.py
+++ b/2d/sliding_block_inclined_boundary/test_benchmark.py
@@ -10,12 +10,12 @@ df1 = pd.read_hdf('results/boundary_inclined_friction/particles-1_4-099000.h5', 
 df2 = pd.read_hdf('results/boundary_inclined_friction/particles-2_4-099000.h5', 'table')
 df3 = pd.read_hdf('results/boundary_inclined_friction/particles-3_4-099000.h5', 'table')
 df = df0
-df.append(df1)
-df.append(df2)
-df.append(df3)
+df = df.append(df1)
+df = df.append(df2)
+df = df.append(df3)
 
-## Assert location of particles
+# Assert location of particles
 assert round(df['coord_x'].min() - 3.177497667722451, 8) == 0.0
-assert round(df['coord_x'].max() - 4.008388126337369, 8) == 0.0
-assert round(df['coord_y'].min() - (-1.8296901482239594), 8) == 0.0
-assert round(df['coord_y'].max() - (-1.2655507481267576), 8) == 0.0
+assert round(df['coord_x'].max() - 4.458142966806158, 8) == 0.0
+assert round(df['coord_y'].min() - (-2.2671931421737326), 8) == 0.0
+assert round(df['coord_y'].max() - (-0.986546553344812), 8) == 0.0


### PR DESCRIPTION
## Describe the PR
Current nightly benchmark is **not** checking global min and max coodinates for sliding block problem. This PR updates benchmark `.py` file to address the bug. 

### The Bug

* `append` function in the `pandas` library returns a new object (i.e., does not update the existing object),
* we are not saving the returned object,
* therefore, MP locations are only checked for the subset of particles in the `particles-0_4-099000.h5` file.

### Validation

The new "min" and "max" values in proposed changes were determined with and without MPI to double-verify the updated values.

## Related Issues/PRs
N/A

## Additional context
N/A
